### PR TITLE
Update docker-compose.ha.yml need for NTTsec

### DIFF
--- a/docker-compose.ha.yml
+++ b/docker-compose.ha.yml
@@ -415,6 +415,7 @@ services:
       - KAFKA_CFG_LOG_RETENTION_BYTES=2000000000
       - KAFKA_CFG_LOG_RETENTION_MS=86400000
       - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
+      - KAFKA_CFG_MESSAGE_MAX_BYTES=1048576
     logging:
       <<: *logging
     volumes:


### PR DESCRIPTION
need for NTTsec to not have error :
msa_kafka.1.54e2pmqdawpg@msav3swarm-worker01    | Exception in thread "main" org.apache.kafka.common.config.ConfigException: Invalid value  for configuration message.max.bytes: Not a number of type INT