### PR TITLE
Create mongo-init.js - add mongo conf

### DIFF
--- a/mongo/mongo-init.js
+++ b/mongo/mongo-init.js
@@ -1,0 +1,13 @@
+db = db.getSiblingDB("msa");
+
+db.createUser({
+    user: "msaUser",
+    pwd: "ubiqube38",
+    roles: [
+      {
+        role: 'readWrite', 
+        db: 'msa'
+      },
+    ],
+  });
+use("msa");


### PR DESCRIPTION
Since msa-api  need to reach mongodb by default. 
We need to have mongodb up with the proper conf.

This doesn’t have impact on customers side